### PR TITLE
アジェンダを削除機能

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -20,10 +20,14 @@ class AgendasController < ApplicationController
       render :new
     end
   end
-  def destoroy
+  def destroy
     @agenda.destroy
-    redirect_to dashboard_url, notice:"タスクを削除しました！"
+    @agenda.team.members.each do |members|
+      AgendaMailer.agenda_mail(members,@agenda).deliver
+    end
+    redirect_to dashboard_url, notice: 'アジェンダを削除しました！'
   end
+
   private
 
   def set_agenda

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,9 @@
+class AgendaMailer < ApplicationMailer
+  default from: 'from@example.com'
+
+  def agenda_mail(user,agenda)
+    @user = user
+    @agenda = agenda
+    mail to: user.email, subject: 'Agendaが削除されました'
+  end
+end

--- a/app/views/agenda_mailer/agenda_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_mail.html.erb
@@ -1,0 +1,2 @@
+<h1>Agenda:<%= @agenda.title %> が削除されました</h1>
+

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -34,6 +34,8 @@
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
                 <%= agenda.title %>
+                  <% if current_user.id == agenda.user.id || current_user.id == agenda.team.owner_id %>
+                <% end %>  
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
アジェンダの削除機能を実装すること（紐づいている記事も削除し、そのアジェンダのチームに属しているメンバー全員に通知メールを送信すること) #1